### PR TITLE
Bump rubocop and standard gem versions

### DIFF
--- a/rubocop-stamped.gemspec
+++ b/rubocop-stamped.gemspec
@@ -2,9 +2,8 @@
 
 Gem::Specification.new do |gem|
   gem.name = "rubocop-stamped"
-  gem.version = "1.0.0"
+  gem.version = "1.1.0"
   gem.authors = ["Philippe Dionne"]
-  gem.email = "p@stamped.ai"
 
   gem.summary = "Code style checking for Stamped Ruby repositories"
   gem.description = "Code style checking for Stamped Ruby repositories, based on RuboCop"
@@ -19,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files config`.split("\n")
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "rubocop", "~> 0.79"
+  gem.add_runtime_dependency "rubocop", "~> 1.22"
   gem.add_runtime_dependency "rubocop-performance"
   gem.add_runtime_dependency "rubocop-rspec"
   gem.add_runtime_dependency "rubocop-md"
-  gem.add_runtime_dependency "standard", "~> 0.2"
+  gem.add_runtime_dependency "standard", "~> 1.4"
 end


### PR DESCRIPTION
* rubocop from "~> 0.79" to "~> 1.22"
* standard from "~> 0.2" to "~> 1.4"